### PR TITLE
Don't pass undefined to numeral.js

### DIFF
--- a/addon/helpers/format-number.js
+++ b/addon/helpers/format-number.js
@@ -2,8 +2,22 @@ import Ember from 'ember';
 import numeral from 'numeral';
 
 export function formatNumber(params, hash) {
-	let { format } = hash || {};
-	return numeral(params).format(format);
+  let { format } = hash || {};
+  let number = params;
+
+  if (Ember.isArray(params)) {
+    number = params[0];
+  }
+
+  if (typeof(number) === 'undefined') {
+    number = null;
+  }
+
+  if (isNaN(number)) {
+    number = null;
+  }
+
+  return numeral(number).format(format);
 }
 
 export default Ember.Helper.helper(formatNumber);

--- a/tests/unit/helpers/format-number-test.js
+++ b/tests/unit/helpers/format-number-test.js
@@ -11,7 +11,7 @@ test('it renders 1230974 as 1.2m', function (assert) {
 	assert.equal(formatNumber(1230974, {format: '0.0a'}), '1.2m');
 });
 
-test('renders [1000] as 1,000', function(assert) {
+test('it renders [1000] as 1,000', function(assert) {
   assert.equal(formatNumber([1000], {format: '0,0'}), '1,000');
 });
 
@@ -19,6 +19,6 @@ test('it renders undefined as 0', function(assert) {
   assert.equal(formatNumber(undefined), '0');
 });
 
-test('renders NaN as 0', function(assert) {
+test('it renders NaN as 0', function(assert) {
   assert.equal(formatNumber(NaN), 0);
 });

--- a/tests/unit/helpers/format-number-test.js
+++ b/tests/unit/helpers/format-number-test.js
@@ -10,3 +10,15 @@ test('it renders 7884486213 as 7.3GB', function (assert) {
 test('it renders 1230974 as 1.2m', function (assert) {
 	assert.equal(formatNumber(1230974, {format: '0.0a'}), '1.2m');
 });
+
+test('renders [1000] as 1,000', function(assert) {
+  assert.equal(formatNumber([1000], {format: '0,0'}), '1,000');
+});
+
+test('it renders undefined as 0', function(assert) {
+  assert.equal(formatNumber(undefined), '0');
+});
+
+test('renders NaN as 0', function(assert) {
+  assert.equal(formatNumber(NaN), 0);
+});


### PR DESCRIPTION
If you pass an undefined value from your template, like `{{format-number foo}}` where `foo` happens to be `undefined` (computed property e.g.) then numeral.js throws something like `Uncaught TypeError: stringOriginal.match is not a function`, which breaks your page and is hard to track down.

![image](https://cloud.githubusercontent.com/assets/221013/10142714/ebbf3116-65d9-11e5-9fae-126218830221.png)

This PR coerces whatever value given to the `format-number`helper into something that numeral.js won't complain about.